### PR TITLE
List suggestions and initial dict examples

### DIFF
--- a/1. Standard Python/Dictionaries/main.py
+++ b/1. Standard Python/Dictionaries/main.py
@@ -1,0 +1,37 @@
+# Traditional Dictionaries
+traditional_dict = {'name': 'Superman', 'secret': 'Clark Kent'}
+
+for k in traditional_dict:  # Iterates over the keys only
+    print(k)
+
+for k, v in traditional_dict.items():  # Iterates over the keys (k) and values (v)
+    print(f'The value of {k} is {v}.')
+
+
+# Nested Dictionaries
+nested_dict = {
+    'name': 'Superman',
+    'secret': 'Clark Kent',
+    'background': {
+        'place_of_origin': 'Krypton',
+        'currently_resides': 'Metropolis',
+    },
+    'allies': [
+        {
+            'name': 'Batman',
+            'secret': 'Bruce Wayne',
+        },
+        {
+            'name': 'Wonder Woman',
+            'secret': 'Diana Prince',
+        }
+    ],
+}
+
+
+# Copying and adding to a dictionary
+expanded_dict = {'team': 'Justice League', **traditional_dict}
+
+
+# Making a dictionary from a list of tuples
+dict_from_list = dict([('name': 'Superman'), ('secret': 'Clark Kent')])

--- a/1. Standard Python/Lists & Tuples/main.py
+++ b/1. Standard Python/Lists & Tuples/main.py
@@ -3,9 +3,11 @@ This is a Python Doc String. The Doc string should exist to describe the overall
 """
 
 # Traditional Lists
-list = ["a", "b", "c"]
-for i in range(0, len(list)):  # Iterates through the list indexes
-    print(list[i])
+list_ = ["a", "b", "c"]
+for i in range(0, len(list_)):  # Iterates through the list indexes
+    print(list_[i])
+for item in list_:
+    print(item)
 
 # Nested Lists
 nlist = [
@@ -14,10 +16,12 @@ nlist = [
     ["g", "h", "i"],
 ]
 for i in range(0, len(nlist)):
-    for ii in range(0, len(nlist[i])):
-        print(nlist[i][ii])
+    for j in range(0, len(nlist[i])):
+        print(nlist[i][j])
 
 # Traditional Tuples - An immutable list of things
 tup = ("a", "b", "c")
 for i in range(0, len(tup)):
     print(tup[i])
+for item in tup:
+    print(item)


### PR DESCRIPTION
- Stylistic changes to list usage
  - Don't use `list` as a variable name.
  - Iterate directly over the items in the `list` or `tuple`.
- Some basic `dict` usage examples, including some fancier constructions.